### PR TITLE
Sort events

### DIFF
--- a/chains/nomad-substrate/src/client.rs
+++ b/chains/nomad-substrate/src/client.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use crate::SubstrateError;
 use avail_subxt::api::nomad_home as home;
 use color_eyre::Result;
-use ethers_core::types::Signature;
+use ethers_core::types::{H256, Signature};
 use nomad_core::{RawCommittedMessage, SignedUpdate, SignedUpdateWithMeta, Update, UpdateMeta};
 use std::convert::TryInto;
 use subxt::ext::sp_runtime::traits::Header;
@@ -78,17 +79,18 @@ impl<T: Config> NomadOnlineClient<T>
             .events()
             .at(Some(hash))
             .await?
-            .find::<home::events::Update>() // TODO: remove dependency on avail metadata
+            .find::<home::events::Update>()
             .into_iter()
             .collect();
 
-        let mut update_events = update_events_res?;
+        let update_events = update_events_res?;
 
         // explicit sort all updates so that previous updates are linked prev -> new root
-        update_events.sort_by(|a, b| a.previous_root.cmp(&b.previous_root));
+        // multiple update events in the same block should be rare or absent
+        let sorted_update_events: Vec<home::events::Update> = sort_update_events(update_events);
 
         // Map update events into SignedUpdates with meta
-        Ok(update_events
+        Ok(sorted_update_events
             .into_iter()
             .map(|ev| {
                 let signature = Signature::try_from(ev.signature.as_ref())
@@ -148,4 +150,85 @@ impl<T: Config> NomadOnlineClient<T>
             })
             .collect())
     }
+}
+
+/// sort_update_events sorts events based on the previous and new root. In most cases there will be
+/// only one event per block.
+fn sort_update_events(update_events: Vec<home::events::Update>) -> Vec<home::events::Update> {
+    if update_events.is_empty() {
+        return vec![];
+    }
+
+    if update_events.len() == 1 {
+        return update_events;
+    }
+
+    let mut map_new_roots: HashMap<H256, home::events::Update> = update_events.iter().map(|event| (event.new_root, event.clone())).collect();
+    let mut map_previous_roots: HashMap<H256, home::events::Update> = update_events.iter().map(|event| (event.previous_root, event.clone())).collect();
+
+    let first_element = update_events.iter().find(|event| !map_new_roots.contains_key(&event.previous_root)).expect("there must be first element");
+
+    let mut sorted: Vec<home::events::Update> = Vec::with_capacity(update_events.len());
+    sorted.push(first_element.clone());
+
+    for _ in update_events {
+        let next = sorted.last().unwrap();
+        if let Some(previous) = map_previous_roots.get(&next.new_root) {
+            sorted.push(previous.clone())
+        }
+    }
+
+    return sorted;
+}
+
+#[test]
+fn test_sorting_of_events() {
+    let update_events: Vec<home::events::Update> = vec![
+        home::events::Update {
+            home_domain: 2000,
+            previous_root: H256([5u8; 32]),
+            new_root: H256([1u8; 32]),
+            signature: vec![],
+        },
+        home::events::Update {
+            home_domain: 2000,
+            previous_root: H256([7u8; 32]),
+            new_root: H256([5u8; 32]),
+            signature: vec![],
+        },
+        home::events::Update {
+            home_domain: 2000,
+            previous_root: H256([1u8; 32]),
+            new_root: H256([3u8; 32]),
+            signature: vec![],
+        },
+    ];
+
+    let sorted = sort_update_events(update_events);
+
+    // assert_eq!(update_events.len(), sorted.len(), "length not equal");
+    assert_eq!(H256([5u8; 32]), sorted[0].new_root, "wrong root position");
+    assert_eq!(H256([1u8; 32]), sorted[1].new_root, "wrong root position");
+    assert_eq!(H256([3u8; 32]), sorted[2].new_root, "wrong root position");
+
+    let single_element_sorted = sort_update_events(vec![{
+        home::events::Update {
+            home_domain: 2000,
+            previous_root: H256([5u8; 32]),
+            new_root: H256([1u8; 32]),
+            signature: vec![4u8],
+        }
+    }]);
+
+    assert_eq!(1, single_element_sorted.len(), "must have one element");
+    assert_eq!(2000, single_element_sorted[0].home_domain);
+    assert_eq!(H256([5u8; 32]), single_element_sorted[0].previous_root);
+    assert_eq!(H256([1u8; 32]), single_element_sorted[0].new_root);
+    assert_eq!(1, single_element_sorted[0].signature.len());
+    assert_eq!(4u8, single_element_sorted[0].signature[0]);
+
+    let empty = sort_update_events(vec![]);
+    assert_eq!(0, empty.len(), "must be empty");
+
+    // println!("{:?}", sorted);
 }

--- a/chains/nomad-substrate/src/client.rs
+++ b/chains/nomad-substrate/src/client.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
 use crate::SubstrateError;
 use avail_subxt::api::nomad_home as home;
 use color_eyre::Result;
-use ethers_core::types::{H256, Signature};
+use ethers_core::types::{Signature, H256};
 use nomad_core::{RawCommittedMessage, SignedUpdate, SignedUpdateWithMeta, Update, UpdateMeta};
+use std::collections::HashMap;
 use std::convert::TryInto;
 use subxt::ext::sp_runtime::traits::Header;
 use subxt::{
@@ -27,8 +27,8 @@ impl<T: Config> std::ops::Deref for NomadOnlineClient<T> {
 }
 
 impl<T: Config> NomadOnlineClient<T>
-    where
-        <T as Config>::BlockNumber: TryInto<u32>,
+where
+    <T as Config>::BlockNumber: TryInto<u32>,
 {
     /// Instantiate a new NomadOnlineClient
     pub fn new(client: OnlineClient<T>, timelag: Option<u8>) -> Self {
@@ -163,10 +163,19 @@ fn sort_update_events(update_events: Vec<home::events::Update>) -> Vec<home::eve
         return update_events;
     }
 
-    let mut map_new_roots: HashMap<H256, home::events::Update> = update_events.iter().map(|event| (event.new_root, event.clone())).collect();
-    let mut map_previous_roots: HashMap<H256, home::events::Update> = update_events.iter().map(|event| (event.previous_root, event.clone())).collect();
+    let mut map_new_roots: HashMap<H256, home::events::Update> = update_events
+        .iter()
+        .map(|event| (event.new_root, event.clone()))
+        .collect();
+    let mut map_previous_roots: HashMap<H256, home::events::Update> = update_events
+        .iter()
+        .map(|event| (event.previous_root, event.clone()))
+        .collect();
 
-    let first_element = update_events.iter().find(|event| !map_new_roots.contains_key(&event.previous_root)).expect("there must be first element");
+    let first_element = update_events
+        .iter()
+        .find(|event| !map_new_roots.contains_key(&event.previous_root))
+        .expect("there must be first element");
 
     let mut sorted: Vec<home::events::Update> = Vec::with_capacity(update_events.len());
     sorted.push(first_element.clone());


### PR DESCRIPTION
Add sorting of events,
Update events are sorted by prevous_root -> new_root which creates a linked list.
Dispatch events are sorted by index leaf in the trie ascending.

